### PR TITLE
Add SVG copy feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The app lets you:
 - Upload an image from your computer
 - Choose a resolution for the output
 - Download the image as PNG, SVG or ICO
+- Generate and copy the SVG code to the clipboard
 - Download React asset files as a zip containing logo512.png, logo192.png, favicon.ico and logo.svg
 - Specify the output file name
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -24,6 +24,23 @@
   gap: 1em;
 }
 
+.svg-code-container {
+  margin-top: 1em;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.svg-code {
+  width: 100%;
+  height: 10rem;
+}
+
+.copy-btn {
+  align-self: flex-end;
+  margin-bottom: 0.5em;
+}
+
 @media (max-width: 600px) {
   .container {
     padding: 1rem;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,8 @@ function App() {
   const [width, setWidth] = useState(300);
   const [height, setHeight] = useState(300);
   const [fileName, setFileName] = useState('image');
+  const [svgCode, setSvgCode] = useState('');
+  const [showSvgCode, setShowSvgCode] = useState(false);
   const canvasRef = useRef(null);
 
   const handleFileChange = (e) => {
@@ -70,6 +72,25 @@ function App() {
     a.download = `${fileName || 'image'}.svg`;
     a.click();
     URL.revokeObjectURL(url);
+  };
+
+  const generateSVGCode = async () => {
+    if (!imgSrc) return;
+    await drawImageToCanvas();
+    const canvas = canvasRef.current;
+    const imgd = ImageTracer.getImgdata(canvas);
+    const svgString = ImageTracer.imagedataToSVG(imgd);
+    setSvgCode(svgString);
+    setShowSvgCode(true);
+  };
+
+  const copySVGToClipboard = async () => {
+    if (!svgCode) return;
+    try {
+      await navigator.clipboard.writeText(svgCode);
+    } catch (err) {
+      console.error('Failed to copy', err);
+    }
   };
 
   const downloadICO = async () => {
@@ -148,9 +169,22 @@ function App() {
           <div className="buttons">
             <button onClick={downloadPNG}>Download PNG</button>
             <button onClick={downloadSVG}>Download SVG</button>
+            <button onClick={generateSVGCode}>SVG Kodu Göster</button>
             <button onClick={downloadICO}>Download ICO</button>
             <button onClick={downloadReactAssets}>Download React Assets</button>
           </div>
+          {showSvgCode && (
+            <div className="svg-code-container">
+              <button className="copy-btn" onClick={copySVGToClipboard}>
+                📋 Kopyala
+              </button>
+              <textarea
+                className="svg-code"
+                value={svgCode}
+                readOnly
+              />
+            </div>
+          )}
         </>
       )}
       <canvas ref={canvasRef} style={{ display: 'none' }} />


### PR DESCRIPTION
## Summary
- let users show and copy generated SVG code
- style the new code box and copy button
- document the SVG copy option

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ba54c66a08327898d26f07ea24dd7