### PR TITLE
Implement aspect ratio checkbox and dark theme

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,6 @@
 .container {
   max-width: 600px;
-  margin: 2rem auto;
+  margin: auto;
   padding: 2rem;
   text-align: center;
   background: rgba(255, 255, 255, 0.15);
@@ -14,6 +14,17 @@
   display: flex;
   justify-content: center;
   gap: 1em;
+}
+
+.presets {
+  display: flex;
+  justify-content: center;
+  gap: 0.5em;
+  margin-bottom: 1em;
+}
+.presets button {
+  padding: 0.3em 0.6em;
+  font-size: 0.9em;
 }
 
 .preview {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,8 +5,10 @@ import './App.css';
 
 function App() {
   const [imgSrc, setImgSrc] = useState(null);
-  const [width, setWidth] = useState(300);
-  const [height, setHeight] = useState(300);
+  const [width, setWidth] = useState('300');
+  const [height, setHeight] = useState('300');
+  const [keepRatio, setKeepRatio] = useState(true);
+  const [ratio, setRatio] = useState(1);
   const [fileName, setFileName] = useState('image');
   const [svgCode, setSvgCode] = useState('');
   const [showSvgCode, setShowSvgCode] = useState(false);
@@ -19,8 +21,9 @@ function App() {
     reader.onload = () => {
       const img = new Image();
       img.onload = () => {
-        setWidth(img.width);
-        setHeight(img.height);
+        setWidth(String(img.width));
+        setHeight(String(img.height));
+        setRatio(img.width / img.height);
         setImgSrc(reader.result);
       };
       img.src = reader.result;
@@ -28,16 +31,52 @@ function App() {
     reader.readAsDataURL(file);
   };
 
+  const handleWidthChange = (e) => {
+    const value = e.target.value;
+    if (keepRatio && value !== '') {
+      const num = parseInt(value);
+      if (!isNaN(num)) {
+        setHeight(String(Math.round(num / ratio)));
+      }
+    }
+    setWidth(value);
+  };
+
+  const handleKeepRatioChange = (e) => {
+    const checked = e.target.checked;
+    if (checked) {
+      const w = parseInt(width);
+      const h = parseInt(height);
+      if (!isNaN(w) && !isNaN(h) && h !== 0) {
+        setRatio(w / h);
+      }
+    }
+    setKeepRatio(checked);
+  };
+
+  const handleHeightChange = (e) => {
+    const value = e.target.value;
+    if (keepRatio && value !== '') {
+      const num = parseInt(value);
+      if (!isNaN(num)) {
+        setWidth(String(Math.round(num * ratio)));
+      }
+    }
+    setHeight(value);
+  };
+
   const drawImageToCanvas = (w = width, h = height) => {
+    const wNum = parseInt(w);
+    const hNum = parseInt(h);
     return new Promise((resolve) => {
       const canvas = canvasRef.current;
       const ctx = canvas.getContext('2d');
       const img = new Image();
       img.onload = () => {
-        canvas.width = w;
-        canvas.height = h;
-        ctx.clearRect(0, 0, w, h);
-        ctx.drawImage(img, 0, 0, w, h);
+        canvas.width = wNum;
+        canvas.height = hNum;
+        ctx.clearRect(0, 0, wNum, hNum);
+        ctx.drawImage(img, 0, 0, wNum, hNum);
         resolve();
       };
       img.src = imgSrc;
@@ -156,14 +195,22 @@ function App() {
         <>
           <div className="controls">
             <label>
-              Width: <input type="number" value={width} onChange={(e) => setWidth(parseInt(e.target.value) || 0)} />
+              Width: <input type="number" value={width} onChange={handleWidthChange} />
             </label>
             <label>
-              Height: <input type="number" value={height} onChange={(e) => setHeight(parseInt(e.target.value) || 0)} />
+              Height: <input type="number" value={height} onChange={handleHeightChange} />
+            </label>
+            <label>
+              <input type="checkbox" checked={keepRatio} onChange={handleKeepRatioChange} /> Keep ratio
             </label>
             <label>
               File name: <input type="text" value={fileName} onChange={(e) => setFileName(e.target.value)} />
             </label>
+          </div>
+          <div className="presets">
+            <button onClick={() => { setWidth('512'); setHeight('512'); }}>512x512</button>
+            <button onClick={() => { setWidth('196'); setHeight('196'); }}>196x196</button>
+            <button onClick={() => { setWidth('64'); setHeight('64'); }}>64x64</button>
           </div>
           <img src={imgSrc} alt="preview" className="preview fade-in" />
           <div className="buttons">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -25,10 +25,11 @@ a:hover {
 body {
   margin: 0;
   display: flex;
-  place-items: center;
+  align-items: center;
+  justify-content: center;
   min-width: 320px;
   min-height: 100vh;
-  background: linear-gradient(135deg, #00b4db, #0083b0);
+  background: linear-gradient(135deg, #1f1c2c, #928dab);
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- center layout vertically
- darken background gradient
- allow empty width/height inputs and maintain aspect ratio
- add aspect ratio lock checkbox and preset resolution buttons

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bb4b280bc83278e5fef79c1145bea