### PR TITLE
Fix multi-image handling

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -202,7 +202,7 @@ function App() {
     ];
 
     for (const asset of assets) {
-      await drawImageToCanvas(asset.width, asset.height);
+      await drawImageToCanvas(undefined, asset.width, asset.height);
       const canvas = canvasRef.current;
       await new Promise((res) => {
         canvas.toBlob(async (blob) => {
@@ -247,7 +247,7 @@ function App() {
   return (
     <div className="container">
       <h1>Image Converter</h1>
-      <input type="file" accept="image/*" onChange={handleFileChange} />
+      <input type="file" accept="image/*" multiple onChange={handleFileChange} />
       {images.length > 0 && (
         <>
           <div className="controls">


### PR DESCRIPTION
## Summary
- allow multi-image selection in `App.jsx`
- fix argument order when generating React assets

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687bbb0d768c8327ba5b7d41f03b7f4d