### PR TITLE
Fix overflow and add second image button

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -31,10 +31,13 @@
   margin-top: 1em;
   position: relative;
   display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .preview-img {
-  max-width: 100%;
+  width: 100%;
+  height: auto;
   position: absolute;
   top: 0;
   left: 0;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,6 +60,12 @@ function App() {
     }
   };
 
+  const goToSecondImage = () => {
+    if (images.length > 1) {
+      handleImageClick(1);
+    }
+  };
+
   const handleWidthChange = (e) => {
     const value = e.target.value;
     if (keepRatio && value !== '') {
@@ -276,14 +282,7 @@ function App() {
             <button onClick={() => { setWidth('196'); setHeight('196'); }}>196x196</button>
             <button onClick={() => { setWidth('64'); setHeight('64'); }}>64x64</button>
           </div>
-          <div
-            className="preview-stack"
-            style={{
-              height: `${height}px`,
-              width: `${width}px`,
-              position: 'relative',
-            }}
-          >
+          <div className="preview-stack">
             {images.map((img, idx) => {
               const offset = (idx - currentIndex + images.length) % images.length;
               return (
@@ -304,6 +303,9 @@ function App() {
               );
             })}
           </div>
+          <button onClick={goToSecondImage} style={{ marginTop: '0.5em' }}>
+            2. Resme Geç
+          </button>
           <div className="buttons">
             <button onClick={downloadPNG}>Download PNG</button>
             <button onClick={downloadJPG}>Download JPG</button>


### PR DESCRIPTION
## Summary
- prevent preview images from overflowing container
- add button to jump to second uploaded image

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bc13fc9b08327acfb9114da2baf51