### PR TITLE
Fix preview stack size for uploaded images

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -33,11 +33,12 @@
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
+  border-radius: 12px;
 }
 
 .preview-img {
   width: 100%;
-  height: auto;
+  height: 100%;
   position: absolute;
   top: 0;
   left: 0;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -282,7 +282,10 @@ function App() {
             <button onClick={() => { setWidth('196'); setHeight('196'); }}>196x196</button>
             <button onClick={() => { setWidth('64'); setHeight('64'); }}>64x64</button>
           </div>
-          <div className="preview-stack">
+          <div
+            className="preview-stack"
+            style={{ width: `${width}px`, height: `${height}px` }}
+          >
             {images.map((img, idx) => {
               const offset = (idx - currentIndex + images.length) % images.length;
               return (


### PR DESCRIPTION
## Summary
- ensure preview area reserves space for uploaded images
- size preview images correctly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bd8c8c2508327bfd2264d50359c9c