### PR TITLE
Update preview card style

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -32,17 +32,19 @@
   position: relative;
   display: inline-block;
   max-width: 100%;
-  overflow: hidden;
+  overflow: visible;
   border-radius: 12px;
 }
 
 .preview-img {
   width: 100%;
   height: 100%;
+  object-fit: cover;
   position: absolute;
   top: 0;
   left: 0;
   border-radius: 12px;
+  border: 2px solid #fff;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   cursor: pointer;
   transition: transform 0.3s, z-index 0.3s;


### PR DESCRIPTION
## Summary
- ensure preview images keep their aspect ratio using `object-fit: cover`
- show a white border around each preview card
- allow cards to overflow so partially hidden cards peek from the right

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687bdc49b2d88327b76f15678107c168