### PR TITLE
Adjust preview and card display

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -31,8 +31,10 @@
   margin-top: 1em;
   position: relative;
   display: inline-block;
+  width: 300px;
+  height: 300px;
   max-width: 100%;
-  overflow: visible;
+  overflow: hidden;
   border-radius: 12px;
 }
 
@@ -47,8 +49,9 @@
   border: 2px solid #fff;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   cursor: pointer;
-  transition: transform 0.3s, z-index 0.3s;
+  transition: transform 0.3s, z-index 0.3s, opacity 0.3s;
 }
+
 
 .preview-img:not(.active) {
   transform: scale(0.9);
@@ -57,6 +60,7 @@
 
 .preview-img.active {
   transform: translateX(0) scale(1);
+  opacity: 1;
 }
 
 .buttons {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -282,10 +282,7 @@ function App() {
             <button onClick={() => { setWidth('196'); setHeight('196'); }}>196x196</button>
             <button onClick={() => { setWidth('64'); setHeight('64'); }}>64x64</button>
           </div>
-          <div
-            className="preview-stack"
-            style={{ width: `${width}px`, height: `${height}px` }}
-          >
+          <div className="preview-stack">
             {images.map((img, idx) => {
               const offset = (idx - currentIndex + images.length) % images.length;
               return (
@@ -300,14 +297,16 @@ function App() {
                     transform:
                       offset === 0
                         ? 'translateX(0)'
-                        : `translateX(${offset * 20}px) scale(0.9)`,
+                        : offset === 1
+                          ? 'translateX(30px) scale(0.9)'
+                          : `translateX(${offset * 20}px) scale(0.9)`,
                   }}
                 />
               );
             })}
           </div>
           <button onClick={goToSecondImage} style={{ marginTop: '0.5em' }}>
-            2. Resme Geç
+            Next
           </button>
           <div className="buttons">
             <button onClick={downloadPNG}>Download PNG</button>


### PR DESCRIPTION
## Summary
- keep image preview size fixed by CSS
- increase offset of the second card
- rename navigation button to "Next"
- fade images when changing cards
- hide overflow so cards stay inside the preview box

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bf7876db48327be633c38fe72e7d8