### PR TITLE
Improve image navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -29,6 +29,7 @@
 
 .preview-stack {
   margin-top: 1em;
+  margin-bottom: 0.5em;
   position: relative;
   display: inline-block;
   width: 300px;
@@ -68,6 +69,11 @@
   display: flex;
   justify-content: center;
   gap: 1em;
+}
+
+.next-btn {
+  display: block;
+  margin: 0.5em auto;
 }
 
 .svg-code-container {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,9 +60,10 @@ function App() {
     }
   };
 
-  const goToSecondImage = () => {
-    if (images.length > 1) {
-      handleImageClick(1);
+  const goToNextImage = () => {
+    if (images.length > 0) {
+      const nextIndex = (currentIndex + 1) % images.length;
+      handleImageClick(nextIndex);
     }
   };
 
@@ -305,7 +306,7 @@ function App() {
               );
             })}
           </div>
-          <button onClick={goToSecondImage} style={{ marginTop: '0.5em' }}>
+          <button onClick={goToNextImage} className="next-btn">
             Next
           </button>
           <div className="buttons">


### PR DESCRIPTION
## Summary
- adjust preview stack spacing and add styling for Next button
- cycle through images with new `goToNextImage` logic

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_687bfa09d36c8327b583e6b32c3b3f12