### PR TITLE
Fix preview offset visibility

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -35,7 +35,7 @@
   width: 300px;
   height: 300px;
   max-width: 100%;
-  overflow: hidden;
+  overflow: visible;
   border-radius: 12px;
 }
 


### PR DESCRIPTION
## Summary
- keep overflow visible so stacked preview images show behind

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bfd94a3f48327b55e5627e03cddb3