### PR TITLE
Fix JPG upload stall

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "dependencies": {
         "exif-js": "^2.3.0",
         "imagetracerjs": "^1.2.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -66,7 +66,7 @@ function App() {
             reader.onload = () => {
               const img = new Image();
               img.onload = () => {
-                EXIF.getData(file, function () {
+                EXIF.getData(img, function () {
                   const orientation = EXIF.getTag(this, 'Orientation') || 1;
                   const make = EXIF.getTag(this, 'Make') || '';
                   const model = EXIF.getTag(this, 'Model') || '';
@@ -84,15 +84,19 @@ function App() {
                   });
                 });
               };
+              img.onerror = () => res(null);
               img.src = reader.result;
             };
+            reader.onerror = () => res(null);
             reader.readAsDataURL(file);
           }),
       ),
     ).then((imgs) => {
-      setImages(imgs);
+      const loaded = imgs.filter(Boolean);
+      if (!loaded.length) return;
+      setImages(loaded);
       setCurrentIndex(0);
-      const first = imgs[0];
+      const first = loaded[0];
       setWidth(String(first.width));
       setHeight(String(first.height));
       setRatio(first.ratio);


### PR DESCRIPTION
## Summary
- handle image load errors and filter invalid images
- use EXIF on the loaded image
- bump app version to 2.1.4

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ca1f5c590832794f9e701f41a2140