### PR TITLE
Improve navigation and controls

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "exif-js": "^2.3.0",
         "imagetracerjs": "^1.2.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -34,6 +34,16 @@
   gap: 1em;
 }
 
+.size-controls {
+  display: flex;
+  gap: 1em;
+}
+
+.keep-ratio {
+  display: flex;
+  align-items: center;
+}
+
 .presets {
   display: flex;
   justify-content: center;
@@ -120,16 +130,13 @@
 /* overlay shown on active image for navigating to next image */
 .next-overlay {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: rgba(0, 0, 0, 0.5);
-  color: #fff;
-  padding: 0.6em 1.2em;
-  border-radius: 8px;
+  inset: 0;
   display: flex;
-  flex-direction: column;
   align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  border-radius: 12px;
   opacity: 0;
   transition: opacity 0.3s ease-in-out;
   pointer-events: none;
@@ -142,14 +149,15 @@
 }
 
 .next-icon {
-  font-size: 2rem;
+  font-size: 2.5rem;
   line-height: 1;
   animation: bounce 1s infinite;
 }
 
 .next-text {
-  font-size: 0.8rem;
+  font-size: 1rem;
   margin-top: 0.2em;
+  font-weight: 600;
 }
 
 
@@ -244,6 +252,11 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .size-controls {
+    flex-direction: row;
+    align-items: center;
   }
 
   .controls input {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -134,6 +134,14 @@ function App() {
     }
   };
 
+  const handlePreviewClick = (index) => {
+    if (index === currentIndex) {
+      goToNextImage();
+    } else {
+      handleImageClick(index);
+    }
+  };
+
   const handleWidthChange = (e) => {
     const value = e.target.value;
     if (keepRatio && value !== '') {
@@ -393,25 +401,27 @@ function App() {
       {images.length > 0 && (
         <>
           <div className="controls">
-            <label>
-              Width: <input type="number" value={width} onChange={handleWidthChange} />
-            </label>
-            <label>
-              Height: <input type="number" value={height} onChange={handleHeightChange} />
-            </label>
-            <label>
-              <input type="checkbox" checked={keepRatio} onChange={handleKeepRatioChange} /> Keep ratio
-            </label>
-            <label>
+            <div className="size-controls">
+              <label>
+                Width: <input type="number" value={width} onChange={handleWidthChange} />
+              </label>
+              <label>
+                Height: <input type="number" value={height} onChange={handleHeightChange} />
+              </label>
+              <label className="keep-ratio">
+                <input type="checkbox" checked={keepRatio} onChange={handleKeepRatioChange} /> Keep ratio
+              </label>
+            </div>
+            <label className="filename-label">
               File name: <input type="text" value={fileName} onChange={(e) => setFileName(e.target.value)} />
             </label>
           </div>
           <div className="presets">
+            <button onClick={() => { setWidth('1024'); setHeight('768'); }}>1024x768</button>
             <button onClick={() => { setWidth('512'); setHeight('512'); }}>512x512</button>
             <button onClick={() => { setWidth('196'); setHeight('196'); }}>196x196</button>
             <button onClick={() => { setWidth('64'); setHeight('64'); }}>64x64</button>
-            <button onClick={() => { setWidth('1024'); setHeight('768'); }}>1024x768</button>
-         </div>
+          </div>
           <div className="preview-stack">
             {images.map((img, idx) => {
               const offset = (idx - currentIndex + images.length) % images.length;
@@ -419,7 +429,7 @@ function App() {
                 <div
                   key={idx}
                   className={`preview-wrapper${offset === 0 ? ' active' : ''}`}
-                  onClick={() => handleImageClick(idx)}
+                  onClick={() => handlePreviewClick(idx)}
                   style={{
                     zIndex: images.length - offset,
                     transform:


### PR DESCRIPTION
## Summary
- group size inputs and ratio lock together
- reorder presets so 1024x768 is first
- show nicer overlay with full preview click support
- update package version to 2.3.0

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cc0a58bcc83278a1c5118058da9f8