### PR TITLE
Fix keep ratio, add top logo and bump minor version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "exif-js": "^2.3.0",
         "imagetracerjs": "^1.2.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -9,6 +9,14 @@
   backdrop-filter: blur(8px);
 }
 
+.logo {
+  display: block;
+  width: 100px;
+  margin: 0 auto 0.5em;
+  pointer-events: none;
+  animation: bounce 3s infinite;
+}
+
 .title {
   position: relative;
   display: inline-block;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react';
 import EXIF from './libs/exif.js';
 import pkg from '../package.json';
 import ImageTracer from 'imagetracerjs';
+import logo from './logo.svg';
 import JSZip from 'jszip';
 import { jsPDF } from 'jspdf';
 import './App.css';
@@ -157,10 +158,17 @@ function App() {
   const handleKeepRatioChange = (e) => {
     const checked = e.target.checked;
     if (checked) {
-      const w = parseInt(width);
-      const h = parseInt(height);
-      if (!isNaN(w) && !isNaN(h) && h !== 0) {
-        setRatio(w / h);
+      const img = images[currentIndex];
+      if (img) {
+        setWidth(String(img.width));
+        setHeight(String(img.height));
+        setRatio(img.ratio);
+      } else {
+        const w = parseInt(width);
+        const h = parseInt(height);
+        if (!isNaN(w) && !isNaN(h) && h !== 0) {
+          setRatio(w / h);
+        }
       }
     }
     setKeepRatio(checked);
@@ -386,6 +394,7 @@ function App() {
 
   return (
     <div className="container">
+      <img src={logo} alt="logo" className="logo" />
       <h1 className="title">
         Image Converter
         <span className="version">v{pkg.version}</span>


### PR DESCRIPTION
## Summary
- show a bouncing logo above the title
- reset dimensions to actual image size when keep ratio is toggled on again
- bump minor version to 2.5.0

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ccd7f0f6483278fa61713582e2237