### PR TITLE
Fix preview and hide logo

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "dependencies": {
         "exif-js": "^2.3.0",
         "imagetracerjs": "^1.2.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,6 @@ import { useState, useRef } from 'react';
 import EXIF from './libs/exif.js';
 import pkg from '../package.json';
 import ImageTracer from 'imagetracerjs';
-import logo from './logo.svg';
 import JSZip from 'jszip';
 import { jsPDF } from 'jspdf';
 import './App.css';
@@ -93,11 +92,9 @@ function App() {
                   lastModified: file.lastModified,
                   device: `${make} ${model}`.trim() || 'Unknown',
                 });
-                URL.revokeObjectURL(url);
               });
             };
             img.onerror = () => {
-              URL.revokeObjectURL(url);
               res(null);
             };
             img.src = url;
@@ -394,7 +391,6 @@ function App() {
 
   return (
     <div className="container">
-      <img src={logo} alt="logo" className="logo" />
       <h1 className="title">
         Image Converter
         <span className="version">v{pkg.version}</span>


### PR DESCRIPTION
## Summary
- bump version to 2.5.1
- remove logo from UI
- avoid revoking uploaded image URLs so preview works

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cd141fa0c83279ff7703a4fa87a28