### PR TITLE
Fix HEIC conversion using updated library

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.1",
       "dependencies": {
         "exif-js": "^2.3.0",
-        "heic2any": "^0.0.4",
+        "heic-to": "^1.2.1",
         "imagetracerjs": "^1.2.6",
         "jspdf": "^2.5.1",
         "jszip": "^3.10.1",
@@ -2170,11 +2170,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/heic2any": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
-      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
-      "license": "MIT"
+    "node_modules/heic-to": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.2.1.tgz",
+      "integrity": "sha512-gtYJ7qPAV8wNTqm7WHWMqJN5qq2js34BavbisEK7N64tA8/TVqjG5S0s8nXzHG4aRxgiMs8kk8kHm/+UBMmdFg==",
+      "license": "LGPL-3.0"
     },
     "node_modules/html2canvas": {
       "version": "1.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "exif-js": "^2.3.0",
-    "heic2any": "^0.0.4",
+    "heic-to": "^1.2.1",
     "imagetracerjs": "^1.2.6",
     "jspdf": "^2.5.1",
     "jszip": "^3.10.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,7 +4,7 @@ import pkg from '../package.json';
 import ImageTracer from 'imagetracerjs';
 import JSZip from 'jszip';
 import { jsPDF } from 'jspdf';
-import heic2any from 'heic2any';
+import { heicTo } from 'heic-to';
 import './App.css';
 
 function App() {
@@ -79,7 +79,7 @@ function App() {
           /\.(heic|heif)$/i.test(file.name)
         ) {
           try {
-            const blob = await heic2any({ blob: file, toType: 'image/jpeg' });
+            const blob = await heicTo({ blob: file, type: 'image/jpeg' });
             f = new File([blob], file.name.replace(/\.(heic|heif)$/i, '.jpg'), {
               type: 'image/jpeg',
               lastModified: file.lastModified,


### PR DESCRIPTION
## Summary
- replace outdated `heic2any` with `heic-to`
- update dependencies and lock file
- switch conversion code to use `heicTo`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cd714142083278aa79c4de51d4290