### PR TITLE
Fix orientation and overlay

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.1",
+  "version": "2.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -148,9 +148,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(90deg, #646cff, #de52ff);
-  background-size: 200% 100%;
-  color: #fff;
+  /* make overlay transparent so it doesn't cover the image */
+  background: none;
   border-radius: 12px;
   opacity: 0;
   transition: opacity 0.3s ease-in-out;
@@ -167,7 +166,8 @@
   font-size: 2.5rem;
   line-height: 1;
   animation: slide-bg 3s linear infinite;
-  background: inherit;
+  background: linear-gradient(90deg, #646cff, #de52ff);
+  background-size: 200% 100%;
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,48 +22,9 @@ function App() {
   const fileInputRef = useRef(null);
   const canvasRef = useRef(null);
 
-  const fixOrientation = (img, orientation) => {
-    if (orientation === 1) {
-      return { src: img.src, width: img.width, height: img.height };
-    }
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d');
-    if (orientation > 4) {
-      canvas.width = img.height;
-      canvas.height = img.width;
-    } else {
-      canvas.width = img.width;
-      canvas.height = img.height;
-    }
-    const w = canvas.width;
-    const h = canvas.height;
-    switch (orientation) {
-      case 2:
-        ctx.transform(-1, 0, 0, 1, w, 0);
-        break;
-      case 3:
-        ctx.transform(-1, 0, 0, -1, w, h);
-        break;
-      case 4:
-        ctx.transform(1, 0, 0, -1, 0, h);
-        break;
-      case 5:
-        ctx.transform(0, 1, 1, 0, 0, 0);
-        break;
-      case 6:
-        ctx.transform(0, 1, -1, 0, h, 0);
-        break;
-      case 7:
-        ctx.transform(0, -1, -1, 0, h, w);
-        break;
-      case 8:
-        ctx.transform(0, -1, 1, 0, 0, w);
-        break;
-      default:
-        break;
-    }
-    ctx.drawImage(img, 0, 0);
-    return { src: canvas.toDataURL(), width: w, height: h };
+  // Keep the original orientation of the image without any transformation
+  const fixOrientation = (img) => {
+    return { src: img.src, width: img.width, height: img.height };
   };
 
   const handleFileChange = (e) => {
@@ -95,10 +56,9 @@ function App() {
           const img = new Image();
           img.onload = () => {
             EXIF.getData(f, function () {
-              const orientation = EXIF.getTag(this, 'Orientation') || 1;
               const make = EXIF.getTag(this, 'Make') || '';
               const model = EXIF.getTag(this, 'Model') || '';
-              const fixed = fixOrientation(img, orientation);
+              const fixed = fixOrientation(img);
               res({
                 src: fixed.src,
                 width: fixed.width,


### PR DESCRIPTION
## Summary
- keep original orientation when loading images
- remove dark overlay when showing next image icon
- bump version to 2.5.2

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cdc7232188327a8468d24e9b64244