### PR TITLE
Fix PDF orientation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.3",
+  "version": "2.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -400,15 +400,24 @@ function App() {
     const pageWidth = temp.internal.pageSize.getWidth();
     const margin = 5;
     const imgWidth = pageWidth - margin * 2;
-    const totalHeight = images.reduce(
-      (sum, img) => sum + (img.height / img.width) * imgWidth + margin,
-      margin,
-    );
+
+    const getOrientedDimensions = (img) => {
+      if (img.orientation && img.orientation > 4) {
+        return { width: img.height, height: img.width };
+      }
+      return { width: img.width, height: img.height };
+    };
+
+    const totalHeight = images.reduce((sum, img) => {
+      const { width, height } = getOrientedDimensions(img);
+      return sum + (height / width) * imgWidth + margin;
+    }, margin);
 
     const pdf = new jsPDF({ unit: 'mm', format: [pageWidth, totalHeight] });
     let y = margin;
     for (const img of images) {
-      const imgHeight = (img.height / img.width) * imgWidth;
+      const { width, height } = getOrientedDimensions(img);
+      const imgHeight = (height / width) * imgWidth;
       const fmt = img.src.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
       const src = await orientImageSrc(img.src, img.orientation);
       pdf.addImage(src, fmt, margin, y, imgWidth, imgHeight);


### PR DESCRIPTION
## Summary
- adjust PDF page calculations for rotated images
- bump frontend version to 2.5.4

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ce6a928bc8327816600f6049186b8