### PR TITLE
Update presets behavior and app version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.4",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.4",
+      "version": "1.5.4",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.4",
+  "version": "1.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -112,6 +112,12 @@ function App() {
     }
   };
 
+  const applyPreset = (w, h) => {
+    setWidth(String(w));
+    setHeight(String(h));
+    setKeepRatio(false);
+  };
+
   const handlePreviewClick = (index) => {
     if (index === currentIndex) {
       goToNextImage();
@@ -462,10 +468,10 @@ function App() {
             </label>
           </div>
           <div className="presets">
-            <button onClick={() => { setWidth('1024'); setHeight('768'); }}>1024x768</button>
-            <button onClick={() => { setWidth('512'); setHeight('512'); }}>512x512</button>
-            <button onClick={() => { setWidth('196'); setHeight('196'); }}>196x196</button>
-            <button onClick={() => { setWidth('64'); setHeight('64'); }}>64x64</button>
+            <button onClick={() => applyPreset(1024, 768)}>1024x768</button>
+            <button onClick={() => applyPreset(512, 512)}>512x512</button>
+            <button onClick={() => applyPreset(196, 196)}>196x196</button>
+            <button onClick={() => applyPreset(64, 64)}>64x64</button>
           </div>
           <div className="preview-stack">
             {images.map((img, idx) => {
@@ -498,7 +504,7 @@ function App() {
                         goToNextImage();
                       }}
                     >
-                      <div className="next-icon">&raquo;&raquo;</div>
+                      <div className="next-icon">&gt;&gt;&gt;</div>
                     </div>
                   )}
                   <div className="preview-info">


### PR DESCRIPTION
## Summary
- bump version to 1.5.4
- adjust next icon to show `>>>`
- disable keep ratio when presets are selected

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ce81d7c808327aca1105701fb1336