### PR TITLE
Fix mobile PDF orientation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.8",
+  "version": "2.5.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import { heicTo } from 'heic-to';
 import './App.css';
 
 function App() {
+  const isMobile = /Mobi|Android/i.test(navigator.userAgent);
   const [images, setImages] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [width, setWidth] = useState('300');
@@ -430,7 +431,7 @@ function App() {
         const { width, height } = getOrientedDimensions(img);
         const imgHeight = (height / width) * imgWidth;
         const fmt = img.src.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
-        const src = await orientImageSrc(img.src, img.orientation);
+        const src = isMobile ? img.src : await orientImageSrc(img.src, img.orientation);
         pdf.addImage(src, fmt, margin, y, imgWidth, imgHeight);
         y += imgHeight + margin;
       }


### PR DESCRIPTION
## Summary
- avoid rotating images for PDF on mobile devices
- bump version to 2.5.9

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d0ac148bc8327a565def4d3d9855a