### PR TITLE
Fix mobile PDF rotation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.8",
+  "version": "2.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.8",
+      "version": "2.5.12",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.8",
+  "version": "2.5.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ function App() {
   const [loading, setLoading] = useState(false);
   const fileInputRef = useRef(null);
   const canvasRef = useRef(null);
+  const isMobile = /Mobi|Android/i.test(navigator.userAgent);
 
   // Keep the original orientation of the image without any transformation.
   // Browsers already display images according to the EXIF orientation tag, so
@@ -427,10 +428,12 @@ function App() {
     let y = margin;
     try {
       for (const img of images) {
-        const { width, height } = getOrientedDimensions(img);
+        const orientation = isMobile ? 6 : img.orientation;
+        const { width, height } = getOrientedDimensions({ ...img, orientation });
         const imgHeight = (height / width) * imgWidth;
         const fmt = img.src.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
-        const src = await orientImageSrc(img.src, img.orientation);
+        const base = await orientImageSrc(img.src, img.orientation);
+        const src = isMobile ? await orientImageSrc(base, 6) : base;
         pdf.addImage(src, fmt, margin, y, imgWidth, imgHeight);
         y += imgHeight + margin;
       }


### PR DESCRIPTION
## Summary
- rotate images once clockwise when generating PDF on mobile
- bump version to 2.5.12

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d0ac148bc8327a565def4d3d9855a