### PR TITLE
Fix mobile orientation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.8",
+  "version": "2.5.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.8",
+      "version": "2.5.14",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.8",
+  "version": "2.5.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -360,6 +360,15 @@ function App() {
       if (!orientation || orientation === 1) return resolve(src);
       const img = new Image();
       img.onload = () => {
+        // Mobile browsers often already apply orientation metadata. If we detect
+        // a rotated orientation but the loaded dimensions indicate the image is
+        // upright, skip the extra rotation to avoid double turning.
+        const alreadyCorrect =
+          /Mobi|Android/i.test(navigator.userAgent) &&
+          orientation > 4 &&
+          img.width < img.height;
+        if (alreadyCorrect) return resolve(src);
+
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
         if (orientation > 4) {


### PR DESCRIPTION
## Summary
- avoid rotating images again when orientation already applied on mobile
- bump version to 2.5.14

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d0ac148bc8327a565def4d3d9855a