### PR TITLE
Fix mobile orientation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.8",
+  "version": "2.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.8",
+      "version": "2.5.15",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.8",
+  "version": "2.5.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -360,6 +360,11 @@ function App() {
       if (!orientation || orientation === 1) return resolve(src);
       const img = new Image();
       img.onload = () => {
+        // If the loaded image already reflects the EXIF rotation, skip
+        // applying it again. This happens on many mobile browsers.
+        const alreadyCorrect = orientation > 4 && img.width < img.height;
+        if (alreadyCorrect) return resolve(src);
+
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
         if (orientation > 4) {
@@ -411,8 +416,10 @@ function App() {
     const margin = 5;
     const imgWidth = pageWidth - margin * 2;
 
+    const alreadyCorrect = (img) => img.orientation > 4 && img.width < img.height;
+
     const getOrientedDimensions = (img) => {
-      if (img.orientation && img.orientation > 4) {
+      if (img.orientation && img.orientation > 4 && !alreadyCorrect(img)) {
         return { width: img.height, height: img.width };
       }
       return { width: img.width, height: img.height };


### PR DESCRIPTION
## Summary
- avoid rotating images again when orientation already applied on mobile
- handle PDF dimensions correctly when orientation has been applied
- bump version to 2.5.15

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d0ac148bc8327a565def4d3d9855a