### PR TITLE
Fix pdf orientation regressions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.8",
+  "version": "2.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.8",
+      "version": "2.5.16",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.16",
+  "version": "2.5.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.16",
+      "version": "2.5.17",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.8",
+  "version": "2.5.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.16",
+  "version": "2.5.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -355,13 +355,17 @@ function App() {
     setMessage('React assets downloaded!');
   };
 
-  const orientImageSrc = (src, orientation) =>
+  const orientImageSrc = (src, orientation, width, height) =>
     new Promise((resolve) => {
       if (!orientation || orientation === 1) return resolve(src);
+      // If the dimensions already reflect the rotated state, skip reapplying it
+      if (orientation > 4 && height > width) return resolve(src);
+
       const img = new Image();
       img.onload = () => {
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
+
         if (orientation > 4) {
           canvas.width = img.height;
           canvas.height = img.width;
@@ -369,6 +373,7 @@ function App() {
           canvas.width = img.width;
           canvas.height = img.height;
         }
+
         const w = canvas.width;
         const h = canvas.height;
         switch (orientation) {
@@ -396,6 +401,7 @@ function App() {
           default:
             break;
         }
+
         ctx.drawImage(img, 0, 0);
         resolve(canvas.toDataURL());
       };
@@ -412,7 +418,7 @@ function App() {
     const imgWidth = pageWidth - margin * 2;
 
     const getOrientedDimensions = (img) => {
-      if (img.orientation && img.orientation > 4) {
+      if (img.orientation && img.orientation > 4 && img.width > img.height) {
         return { width: img.height, height: img.width };
       }
       return { width: img.width, height: img.height };
@@ -430,7 +436,12 @@ function App() {
         const { width, height } = getOrientedDimensions(img);
         const imgHeight = (height / width) * imgWidth;
         const fmt = img.src.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
-        const src = await orientImageSrc(img.src, img.orientation);
+        const src = await orientImageSrc(
+          img.src,
+          img.orientation,
+          img.width,
+          img.height,
+        );
         pdf.addImage(src, fmt, margin, y, imgWidth, imgHeight);
         y += imgHeight + margin;
       }


### PR DESCRIPTION
## Summary
- revert orientation check that broke portrait images
- compute rotated dimensions consistently
- bump version to 2.5.16

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d0ac148bc8327a565def4d3d9855a