### PR TITLE
Fix PDF rotation issue for portrait images

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -355,11 +355,10 @@ function App() {
     setMessage('React assets downloaded!');
   };
 
-  const orientImageSrc = (src, orientation, width, height) =>
+  // Rotate the image data according to its EXIF orientation
+  const orientImageSrc = (src, orientation) =>
     new Promise((resolve) => {
       if (!orientation || orientation === 1) return resolve(src);
-      // If the dimensions already reflect the rotated state, skip reapplying it
-      if (orientation > 4 && height > width) return resolve(src);
 
       const img = new Image();
       img.onload = () => {
@@ -418,7 +417,7 @@ function App() {
     const imgWidth = pageWidth - margin * 2;
 
     const getOrientedDimensions = (img) => {
-      if (img.orientation && img.orientation > 4 && img.width > img.height) {
+      if (img.orientation && img.orientation > 4) {
         return { width: img.height, height: img.width };
       }
       return { width: img.width, height: img.height };
@@ -436,12 +435,7 @@ function App() {
         const { width, height } = getOrientedDimensions(img);
         const imgHeight = (height / width) * imgWidth;
         const fmt = img.src.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
-        const src = await orientImageSrc(
-          img.src,
-          img.orientation,
-          img.width,
-          img.height,
-        );
+        const src = await orientImageSrc(img.src, img.orientation);
         pdf.addImage(src, fmt, margin, y, imgWidth, imgHeight);
         y += imgHeight + margin;
       }


### PR DESCRIPTION
## Summary
- rotate images according to EXIF orientation when generating PDFs
- simplify orientation handling logic

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d2a70b46483278227a5c3da42aa0b