### PR TITLE
Fix portrait rotation in PDF

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.17",
+  "version": "2.5.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.17",
+      "version": "2.5.18",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.17",
+  "version": "2.5.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -355,18 +355,12 @@ function App() {
     setMessage('React assets downloaded!');
   };
 
-//<<<<<<< ryop6i-codex/fix-pdf-generation-direction-on-mobile
-//  const orientImageSrc = (src, orientation, width, height) =>
-//    new Promise((resolve) => {
-//      if (!orientation || orientation === 1) return resolve(src);
-//      // If the dimensions already reflect the rotated state, skip reapplying it
-//      if (orientation > 4 && height > width) return resolve(src);
-//=======
   // Rotate the image data according to its EXIF orientation
-  const orientImageSrc = (src, orientation) =>
+  const orientImageSrc = (src, orientation, width, height) =>
     new Promise((resolve) => {
       if (!orientation || orientation === 1) return resolve(src);
-//>>>>>>> main
+      // Skip rotation if the image dimensions already match the oriented state
+      if (orientation > 4 && height > width) return resolve(src);
 
       const img = new Image();
       img.onload = () => {


### PR DESCRIPTION
## Summary
- prevent double rotation when generating PDFs by checking image dimensions before applying orientation
- bump version to 2.5.18

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d381af82083278104f6712272765e