### PR TITLE
Remove SVG download UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.18",
+  "version": "2.5.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.18",
+      "version": "2.5.19",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.18",
+  "version": "2.5.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -238,26 +238,6 @@ function App() {
     setMessage('JPG download complete!');
   };
 
-  const downloadSVG = async () => {
-    if (!images.length) return;
-    const targets = images.length > 1 ? images : [images[currentIndex]];
-    for (let i = 0; i < targets.length; i++) {
-      const img = targets[i];
-      await drawImageToCanvas(img.src);
-      const canvas = canvasRef.current;
-      const imgd = ImageTracer.getImgdata(canvas);
-      const svgString = ImageTracer.imagedataToSVG(imgd);
-      const blob = new Blob([svgString], { type: 'image/svg+xml' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      const suffix = targets.length > 1 ? `-${i + 1}` : '';
-      a.download = `${fileName || 'image'}${suffix}.svg`;
-      a.click();
-      URL.revokeObjectURL(url);
-    }
-    setMessage('SVG download complete!');
-  };
 
   const generateSVGCode = async () => {
     if (!images.length) return;
@@ -540,7 +520,6 @@ function App() {
           <div className="buttons">
             <button onClick={downloadPNG}>Download PNG</button>
             <button onClick={downloadJPG}>Download JPG</button>
-            <button onClick={downloadSVG}>Download SVG</button>
             <button onClick={downloadICO}>Download ICO</button>
             <button onClick={downloadPDF}>Download PDF</button>
             <button onClick={downloadReactAssets}>Download React Assets</button>


### PR DESCRIPTION
## Summary
- remove "Download SVG" button from the app
- delete unused SVG download handler
- bump version to 2.5.19

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d4df36e8c8327b39876948ad202ba