### PR TITLE
Fix orientation of mobile images in PDF

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.19",
+  "version": "2.5.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.19",
+      "version": "2.5.20",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.19",
+  "version": "2.5.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -336,11 +336,9 @@ function App() {
   };
 
   // Rotate the image data according to its EXIF orientation
-  const orientImageSrc = (src, orientation, width, height) =>
+  const orientImageSrc = (src, orientation) =>
     new Promise((resolve) => {
       if (!orientation || orientation === 1) return resolve(src);
-      // Skip rotation if the image dimensions already match the oriented state
-      if (orientation > 4 && height > width) return resolve(src);
 
       const img = new Image();
       img.onload = () => {
@@ -399,7 +397,7 @@ function App() {
     const imgWidth = pageWidth - margin * 2;
 
     const getOrientedDimensions = (img) => {
-      if (img.orientation && img.orientation > 4 && img.width > img.height) {
+      if (img.orientation && img.orientation > 4) {
         return { width: img.height, height: img.width };
       }
       return { width: img.width, height: img.height };
@@ -417,12 +415,7 @@ function App() {
         const { width, height } = getOrientedDimensions(img);
         const imgHeight = (height / width) * imgWidth;
         const fmt = img.src.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
-        const src = await orientImageSrc(
-          img.src,
-          img.orientation,
-          img.width,
-          img.height,
-        );
+        const src = await orientImageSrc(img.src, img.orientation);
         pdf.addImage(src, fmt, margin, y, imgWidth, imgHeight);
         y += imgHeight + margin;
       }


### PR DESCRIPTION
## Summary
- fix orientation logic so vertical images render correctly in PDFs
- always swap dimensions when orientation requires rotation
- bump frontend version to 2.5.20

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d582c04c4832789eeeea19514cc97