### PR TITLE
Adjust mobile layout and bump version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.20",
+  "version": "2.5.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.20",
+      "version": "2.5.21",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.20",
+  "version": "2.5.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -333,6 +333,10 @@
     align-items: center;
   }
 
+  .size-controls label {
+    flex: 1;
+  }
+
   .controls input {
     width: 100%;
   }


### PR DESCRIPTION
## Summary
- extend mobile `size-controls` labels to evenly share the row
- bump app version to 2.5.21

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687dee343d5083279f2f7dac30ba5307