### PR TITLE
Improve PDF image layout

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.21",
+  "version": "2.5.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.21",
+      "version": "2.5.22",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.21",
+  "version": "2.5.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -405,7 +405,8 @@ function App() {
 
     const totalHeight = images.reduce((sum, img) => {
       const { width, height } = getOrientedDimensions(img);
-      return sum + (height / width) * imgWidth + margin;
+      const scale = Math.min(imgWidth / width, 1);
+      return sum + height * scale + margin;
     }, margin);
 
     const pdf = new jsPDF({ orientation: 'portrait', unit: 'mm', format: [pageWidth, totalHeight] });
@@ -413,11 +414,14 @@ function App() {
     try {
       for (const img of images) {
         const { width, height } = getOrientedDimensions(img);
-        const imgHeight = (height / width) * imgWidth;
+        const scale = Math.min(imgWidth / width, 1);
+        const w = width * scale;
+        const h = height * scale;
+        const x = (pageWidth - w) / 2;
         const fmt = img.src.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
         const src = await orientImageSrc(img.src, img.orientation);
-        pdf.addImage(src, fmt, margin, y, imgWidth, imgHeight);
-        y += imgHeight + margin;
+        pdf.addImage(src, fmt, x, y, w, h);
+        y += h + margin;
       }
       pdf.save(`${fileName || 'images'}.pdf`);
       setMessage('PDF created successfully!');


### PR DESCRIPTION
## Summary
- keep images centered and within page margins in PDFs
- bump app version to 2.5.22

## Testing
- `npm install`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e88022b3c8327a764dc0e59427d16