### PR TITLE
Improve PDF orientation on mobile

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.21",
+  "version": "2.5.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.21",
+      "version": "2.5.23",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.21",
+  "version": "2.5.23",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- read EXIF orientation manually
- keep dimension info aligned with EXIF orientation
- avoid rotating images twice when creating PDFs
- bump version to 2.5.23

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e88022b3c8327a764dc0e59427d16