### PR TITLE
Improve PDF orientation on mobile

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.21",
+  "version": "2.5.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.21",
+      "version": "2.5.23",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.21",
+  "version": "2.5.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,12 +23,51 @@ function App() {
   const fileInputRef = useRef(null);
   const canvasRef = useRef(null);
 
-  // Keep the original orientation of the image without any transformation.
-  // Browsers already display images according to the EXIF orientation tag, so
-  // we simply return the source and dimensions as-is.
-  const fixOrientation = (img) => {
-    return { src: img.src, width: img.width, height: img.height };
-  };
+  // Get the displayed dimensions of an image. Browsers already apply EXIF
+  // orientation when decoding, so the width and height properties reflect the
+  // oriented image. We simply return these values.
+  const fixOrientation = (img) => ({
+    src: img.src,
+    width: img.width,
+    height: img.height,
+  });
+
+  // Read the EXIF orientation value directly from a File.
+  const getOrientation = (file) =>
+    new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const view = new DataView(e.target.result);
+        if (view.getUint16(0, false) !== 0xffd8) return resolve(1);
+        let offset = 2;
+        const length = view.byteLength;
+        while (offset < length) {
+          const marker = view.getUint16(offset, false);
+          offset += 2;
+          if (marker === 0xffe1) {
+            offset += 2;
+            if (view.getUint32(offset, false) !== 0x45786966) break;
+            offset += 6;
+            const little = view.getUint16(offset, false) === 0x4949;
+            offset += view.getUint32(offset + 4, little);
+            const tags = view.getUint16(offset, little);
+            offset += 2;
+            for (let i = 0; i < tags; i++) {
+              if (view.getUint16(offset + i * 12, little) === 0x0112) {
+                return resolve(view.getUint16(offset + i * 12 + 8, little));
+              }
+            }
+          } else if ((marker & 0xff00) !== 0xff00) {
+            break;
+          } else {
+            offset += view.getUint16(offset, false);
+          }
+        }
+        return resolve(1);
+      };
+      reader.onerror = () => resolve(1);
+      reader.readAsArrayBuffer(file);
+    });
 
   const handleFileChange = (e) => {
     const files = Array.from(e.target.files || []);
@@ -54,12 +93,12 @@ function App() {
           }
         }
 
+        const orientation = await getOrientation(f);
         return new Promise((res) => {
           const url = URL.createObjectURL(f);
           const img = new Image();
           img.onload = () => {
             EXIF.getData(f, function () {
-              const orientation = EXIF.getTag(this, 'Orientation') || 1;
               const make = EXIF.getTag(this, 'Make') || '';
               const model = EXIF.getTag(this, 'Model') || '';
               const fixed = fixOrientation(img);
@@ -405,7 +444,8 @@ function App() {
 
     const totalHeight = images.reduce((sum, img) => {
       const { width, height } = getOrientedDimensions(img);
-      return sum + (height / width) * imgWidth + margin;
+      const scale = Math.min(imgWidth / width, 1);
+      return sum + height * scale + margin;
     }, margin);
 
     const pdf = new jsPDF({ orientation: 'portrait', unit: 'mm', format: [pageWidth, totalHeight] });
@@ -413,11 +453,14 @@ function App() {
     try {
       for (const img of images) {
         const { width, height } = getOrientedDimensions(img);
-        const imgHeight = (height / width) * imgWidth;
+        const scale = Math.min(imgWidth / width, 1);
+        const w = width * scale;
+        const h = height * scale;
+        const x = (pageWidth - w) / 2;
         const fmt = img.src.startsWith('data:image/jpeg') ? 'JPEG' : 'PNG';
         const src = await orientImageSrc(img.src, img.orientation);
-        pdf.addImage(src, fmt, margin, y, imgWidth, imgHeight);
-        y += imgHeight + margin;
+        pdf.addImage(src, fmt, x, y, w, h);
+        y += h + margin;
       }
       pdf.save(`${fileName || 'images'}.pdf`);
       setMessage('PDF created successfully!');


### PR DESCRIPTION
## Summary
- fix dimensions for images that have EXIF rotation
- compute oriented size when creating PDFs

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e88022b3c8327a764dc0e59427d16