### PR TITLE
Fix HEIC orientation handling

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.5.23",
       "dependencies": {
         "exif-js": "^2.3.0",
+        "exifr": "^7.1.3",
         "heic-to": "^1.2.1",
         "imagetracerjs": "^1.2.6",
         "jspdf": "^2.5.1",
@@ -2014,6 +2015,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/exif-js/-/exif-js-2.3.0.tgz",
       "integrity": "sha512-1Og9pAzG2FZRVlaavH8bB8BTeHcjMdJhKmeQITkX+uLRCD0xPtKAdZ2clZmQdJ56p9adXtJ8+jwrGp/4505lYg==",
+      "license": "MIT"
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "exif-js": "^2.3.0",
+    "exifr": "^7.1.3",
     "heic-to": "^1.2.1",
     "imagetracerjs": "^1.2.6",
     "jspdf": "^2.5.1",


### PR DESCRIPTION
## Summary
- use exifr to detect EXIF orientation
- read orientation before converting HEIC files
- add exifr dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fdc2fadd883279eedfcd5ca9d08da