### PR TITLE
Fix landscape PDF layout

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.23",
+  "version": "2.5.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.23",
+      "version": "2.5.24",
       "dependencies": {
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.5.23",
+  "version": "2.5.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -360,7 +360,9 @@ function App() {
   const downloadPDF = async () => {
     if (!images.length) return;
     setLoading(true);
-    const temp = new jsPDF({ orientation: 'portrait' });
+    const isLandscape = images.length === 1 && images[0].width > images[0].height;
+    const orientation = isLandscape ? 'landscape' : 'portrait';
+    const temp = new jsPDF({ orientation });
     const pageWidth = temp.internal.pageSize.getWidth();
     const margin = 5;
     const imgWidth = pageWidth - margin * 2;
@@ -376,7 +378,7 @@ function App() {
       return sum + height * scale + margin;
     }, margin);
 
-    const pdf = new jsPDF({ orientation: 'portrait', unit: 'mm', format: [pageWidth, totalHeight] });
+    const pdf = new jsPDF({ orientation, unit: 'mm', format: [pageWidth, totalHeight] });
     let y = margin;
     try {
       for (const img of images) {


### PR DESCRIPTION
## Summary
- handle single landscape image PDFs correctly by dynamically setting jsPDF orientation
- bump frontend version to v2.5.24

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fef3908148327940ff2d82f543ad5