### PR TITLE
Fix ffmpeg import for Vite build

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.5.24",
       "dependencies": {
         "@ffmpeg/ffmpeg": "^0.12.4",
+        "@ffmpeg/util": "^0.12.2",
         "exif-js": "^2.3.0",
         "heic-to": "^1.2.1",
         "imagetracerjs": "^1.2.6",
@@ -949,6 +950,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/@ffmpeg/util": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/util/-/util-0.12.2.tgz",
+      "integrity": "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,12 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ffmpeg/ffmpeg": "^0.12.4",
+    "@ffmpeg/util": "^0.12.2",
     "exif-js": "^2.3.0",
     "heic-to": "^1.2.1",
     "imagetracerjs": "^1.2.6",
     "jspdf": "^2.5.1",
     "jszip": "^3.10.1",
-    "@ffmpeg/ffmpeg": "^0.12.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
## Summary
- update VideoConverter to use new `FFmpeg` API
- include `@ffmpeg/util` for `fetchFile`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fa2bcc71c8327a1a5ba4d757c256e