### PR TITLE
Refine media tools layout and navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,20 +5,61 @@ import VideoConverter from './VideoConverter.jsx';
 
 function App() {
   const [mode, setMode] = useState(null);
+  const [initImages, setInitImages] = useState(null);
+  const [initVideo, setInitVideo] = useState(null);
+
+  const resetHome = () => {
+    setMode(null);
+    setInitImages(null);
+    setInitVideo(null);
+  };
+
+  const handleHomeImage = (e) => {
+    const files = e.target.files;
+    if (files && files.length) {
+      setInitImages(files);
+      setMode('image');
+    }
+    e.target.value = '';
+  };
+
+  const handleHomeVideo = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      setInitVideo(file);
+      setMode('video');
+    }
+    e.target.value = '';
+  };
 
   if (mode === 'image') {
-    return <ImageConverter onHome={() => setMode(null)} />;
+    return <ImageConverter onHome={resetHome} initialFiles={initImages} />;
   }
   if (mode === 'video') {
-    return <VideoConverter onHome={() => setMode(null)} />;
+    return <VideoConverter onHome={resetHome} initialFile={initVideo} />;
   }
 
   return (
     <div className="container">
       <h1 className="title">Media Tools</h1>
+      <input
+        id="home-image-input"
+        type="file"
+        accept="image/*"
+        multiple
+        style={{ display: 'none' }}
+        onChange={handleHomeImage}
+      />
+      <input
+        id="home-video-input"
+        type="file"
+        accept="video/*"
+        style={{ display: 'none' }}
+        onChange={handleHomeVideo}
+      />
       <div className="buttons">
-        <button onClick={() => setMode('image')}>Resim Yükle</button>
-        <button onClick={() => setMode('video')}>Video Yükle</button>
+        <label htmlFor="home-image-input" className="file-label">Resim Yükle</label>
+        <label htmlFor="home-video-input" className="file-label">Video Yükle</label>
       </div>
     </div>
   );

--- a/frontend/src/ImageConverter.jsx
+++ b/frontend/src/ImageConverter.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import EXIF from './libs/exif.js';
 import pkg from '../package.json';
 import ImageTracer from 'imagetracerjs';
@@ -7,7 +7,7 @@ import { jsPDF } from 'jspdf';
 import { heicTo } from 'heic-to';
 import './App.css';
 
-function ImageConverter({ onHome }) {
+function ImageConverter({ onHome, initialFiles }) {
   const [images, setImages] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [width, setWidth] = useState('300');
@@ -98,6 +98,13 @@ function ImageConverter({ onHome }) {
       setFileLabel('Choose Another');
     });
   };
+
+  useEffect(() => {
+    if (initialFiles && initialFiles.length) {
+      handleFileChange({ target: { files: initialFiles } });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialFiles]);
 
   const handleImageClick = (index) => {
     setCurrentIndex(index);
@@ -405,7 +412,7 @@ function ImageConverter({ onHome }) {
         Image Converter
         <span className="version">v{pkg.version}</span>
       </h1>
-      <button className="home-btn reset-btn" onClick={onHome}>Anasayfa</button>
+      <button className="home-btn reset-btn" onClick={onHome} aria-label="Anasayfa">🏠</button>
       <input
         id="file-input"
         ref={fileInputRef}


### PR DESCRIPTION
## Summary
- Replace home buttons with icons across converters
- Align video converter layout with image converter, adding filename input and preview info
- Allow direct image/video uploads from the landing page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fab7958548327bedf2c1a659fea47