### PR TITLE
Refine media converters layout and playback

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -220,6 +220,25 @@
   transform: scale(1.05);
 }
 
+.top-bar {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1em;
+}
+
+.top-bar .title {
+  margin-bottom: 0;
+}
+
+.top-bar .file-label {
+  margin: 0;
+}
+
+.top-bar .home-btn {
+  margin: 0 0 0 auto;
+}
+
 .message {
   margin-top: 1em;
   display: flex;

--- a/frontend/src/ImageConverter.jsx
+++ b/frontend/src/ImageConverter.jsx
@@ -37,6 +37,7 @@ function ImageConverter({ onHome, initialFiles }) {
     const files = Array.from(e.target.files || []);
     if (files.length === 0) return;
 
+    setLoading(true);
     Promise.all(
       files.map(async (file) => {
         let f = file;
@@ -96,6 +97,8 @@ function ImageConverter({ onHome, initialFiles }) {
       setSvgCodes([]);
       setShowSvgCode(false);
       setFileLabel('Choose Another');
+    }).finally(() => {
+      setLoading(false);
     });
   };
 
@@ -408,11 +411,14 @@ function ImageConverter({ onHome, initialFiles }) {
 
   return (
     <div className="container">
-      <h1 className="title">
-        Image Converter
-        <span className="version">v{pkg.version}</span>
-      </h1>
-      <button className="home-btn reset-btn" onClick={onHome} aria-label="Anasayfa">🏠</button>
+      <div className="top-bar">
+        <h1 className="title">
+          Image Converter
+          <span className="version">v{pkg.version}</span>
+        </h1>
+        <label htmlFor="file-input" className="file-label">{fileLabel}</label>
+        <button className="home-btn reset-btn" onClick={onHome} aria-label="Anasayfa">🏠</button>
+      </div>
       <input
         id="file-input"
         ref={fileInputRef}
@@ -422,7 +428,6 @@ function ImageConverter({ onHome, initialFiles }) {
         onChange={handleFileChange}
         style={{ display: 'none' }}
       />
-      <label htmlFor="file-input" className="file-label">{fileLabel}</label>
       {images.length > 0 && (
         <>
           <div className="controls">

--- a/frontend/src/VideoConverter.jsx
+++ b/frontend/src/VideoConverter.jsx
@@ -175,8 +175,11 @@ export default function VideoConverter({ onHome, initialFile }) {
 
   return (
     <div className="container">
-      <h1 className="title">Video Converter</h1>
-      <button className="home-btn reset-btn" onClick={onHome} aria-label="Anasayfa">🏠</button>
+      <div className="top-bar">
+        <h1 className="title">Video Converter</h1>
+        <label htmlFor="video-input" className="file-label">{fileLabel}</label>
+        <button className="home-btn reset-btn" onClick={onHome} aria-label="Anasayfa">🏠</button>
+      </div>
       <input
         id="video-input"
         ref={fileInputRef}
@@ -185,7 +188,6 @@ export default function VideoConverter({ onHome, initialFile }) {
         onChange={handleFileChange}
         style={{ display: 'none' }}
       />
-      <label htmlFor="video-input" className="file-label">{fileLabel}</label>
       {videoFile && (
         <>
           <div className="controls">
@@ -214,7 +216,16 @@ export default function VideoConverter({ onHome, initialFile }) {
           </div>
           <div className="preview-stack">
             <div className="preview-wrapper active">
-              <video src={videoURL} className="preview-img active" />
+              <video
+                src={videoURL}
+                className="preview-img active"
+                playsInline
+                onClick={(e) => {
+                  const vid = e.target;
+                  if (vid.paused) vid.play();
+                  else vid.pause();
+                }}
+              />
               <div className="preview-info">
                 {origWidth}x{origHeight} | {(videoFile.size / 1024 / 1024).toFixed(1)}MB
                 <br />


### PR DESCRIPTION
## Summary
- Show loading indicator while images initialize to avoid interim screen
- Allow video previews to play or pause on click
- Arrange converter headers with a right-aligned home button and gaps between elements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fae6ad0d48327a302a91c7c8d1af4